### PR TITLE
docs: fix seed reference and unify Builder Discord invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Official documentation for [Nouns Builder](https://nouns.build/), a protocol for
 - 🌐 [Live Site](https://builder-docs.vercel.app)
 - 🏗️ [Nouns Builder App](https://nouns.build/)
 - 🐙 [GitHub](https://github.com/BuilderOSS)
-- 💬 [Discord](https://discord.gg/bTygNksyRb)
+- 💬 [Discord](https://discord.gg/f845eBCyyb)
 - 🟣 [Farcaster](https://farcaster.xyz/~/channel/builder)
 
 ## 🚀 Project Structure

--- a/src/content/docs/guides/img-config.mdx
+++ b/src/content/docs/guides/img-config.mdx
@@ -32,7 +32,7 @@ Currently no maximum image size is set on the frontend, which is **subject to ch
 
 ## Seed Generation
 The seed is used to create a random combination of properties for the DAO NFTs.
-It is generated in the [Metadata Render Contract](https://github.com/ourzora/nouns-protocol/blob/main/src/token/metadata/MetadataRenderer.sol#L279) by calling `_generateSeed` with the current tokenId and salting the hash with block data.
+It is generated in the [Metadata Render Contract](https://github.com/BuilderOSS/nouns-protocol/blob/main/src/token/metadata/MetadataRenderer.sol#L329) by calling `_generateSeed` with the current tokenId and salting the hash with block data.
 
 ```
 function _generateSeed(uint256 _tokenId) private view returns (uint256) {

--- a/src/content/docs/onboarding/community-support.mdx
+++ b/src/content/docs/onboarding/community-support.mdx
@@ -16,7 +16,7 @@ The Builder DAO Discord is the central hub for discussion, coordination, and sup
 
 **To join:**
 
-1. Visit discord.gg/builderdao
+1. Visit [discord.gg/f845eBCyyb](https://discord.gg/f845eBCyyb)
 2. Connect your wallet (if prompted)
 3. Introduce yourself in the #introductions channel!
 


### PR DESCRIPTION
## Summary
- fix the MetadataRenderer reference in img-config so the `_generateSeed` link points to the correct function definition
- unify core Builder Discord references to a single invite code across README, config, and docs

## Validation
- npm run build

## Deliberately out of scope
- Smart Invoice support links in escrow docs, which may be intentionally partner-specific
- roadmap and dated planning references
- llm.txt, llm-full.txt, robots.txt, and sitemap work

## Suggested maintainer review
- confirm `f845eBCyyb` is the preferred canonical Discord invite for Builder core/community surfaces
- confirm partner/integration docs should keep their own support invites when appropriate
